### PR TITLE
Removed the extra comma in bootstrap cf template

### DIFF
--- a/templates/dev/bootstrap.json
+++ b/templates/dev/bootstrap.json
@@ -29,7 +29,7 @@
             }]
         }
     }
-    },
+    }
   },
   "Conditions": {},
   "AWSTemplateFormatVersion": "2010-09-09",


### PR DESCRIPTION
To make the JSON syntax checker happier, as the trailing comma is not allowed. 